### PR TITLE
Fix crash on CentOS 8

### DIFF
--- a/src/bam2R.cpp
+++ b/src/bam2R.cpp
@@ -32,7 +32,7 @@ int N = 11;
 
 extern "C" {
 
-void bam2R_pileup_function(const bam_pileup1_t *pl, int pos, int n_plp, nttable_t nttable)
+void bam2R_pileup_function(const bam_pileup1_t *pl, int pos, int n_plp, nttable_t& nttable)
 {
   int i, s;
   int len = nttable.end - nttable.beg;


### PR DESCRIPTION
Shearwater (rather mysteriously) crashes when compiled with CentOS 8's GCC 8.3.1-4.

There is no need to copy nttable each time bam2R_pileup_function() is called, and in particular nttable.i (though currently unused) counts function calls so the increment should affect the original nttable in bam2R().

Making this change prevents the segfault when compiled with this compiler. It's not clear what's going on here or whether that's a compiler problem or not, but making this change improves the _bam2R.cpp_ code anyway.
