### PR TITLE
Fix corrupted VCF output due to broken addition of the `##date` header

### DIFF
--- a/R/deepSNV-functions.R
+++ b/R/deepSNV-functions.R
@@ -263,6 +263,7 @@ RF <- function(freq, total = FALSE){
 			samples <- sub("/.+/","",deepSNV@files)
 		else
 			samples <- c("test","control")
+		headerTemplate = scanVcfHeader(system.file("extdata", "deepSNV.vcf", package="deepSNV"))
 		v = VCF(
 				rowRanges=GRanges(table$chr, 
 						IRanges(table$pos - (isDel | isIns), width=1 + (isDel | isIns)), 
@@ -282,12 +283,13 @@ RF <- function(freq, total = FALSE){
 						BW = cbind(table$n.tst.bw, table$n.ctrl.bw),
 						DFW = cbind(table$cov.tst.fw, table$cov.ctrl.fw),
 						DBW = cbind(table$cov.tst.bw, table$cov.ctrl.bw)),
-				metadata = list(header = scanVcfHeader(system.file("extdata", "deepSNV.vcf", package="deepSNV"))),
+				exptData = list(header = VCFHeader(
+						reference = reference(headerTemplate),
+						samples = as.character(samples),
+						header = append(header(headerTemplate), DataFrame(date=paste(Sys.time()))))),
 				colData = DataFrame(samples=1:length(samples), row.names=samples),
 				collapsed=TRUE
 		)
-		metadata(v)$header@samples <- samples
-		meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
 		
 		return(sort(v))
 	}

--- a/R/deepSNV-functions.R
+++ b/R/deepSNV-functions.R
@@ -287,7 +287,7 @@ RF <- function(freq, total = FALSE){
 				collapsed=TRUE
 		)
 		metadata(v)$header@samples <- samples
-		metadata(v)$header@header$META["date",1] <- paste(Sys.time())
+		meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
 		
 		return(sort(v))
 	}

--- a/R/shearwater-functions.R
+++ b/R/shearwater-functions.R
@@ -123,6 +123,7 @@ bf2Vcf <- function(BF, counts, regions, samples = 1:nrow(counts), err = NULL, mu
 #	m = match(gr[o], rd)
 #	alt = lapply(split(c("A","T","C","G","")[w[o,3]], m), paste, collapse="")
 	if(!mvcf){
+		headerTemplate = scanVcfHeader(system.file("extdata", "shearwater.vcf", package="deepSNV"))
 		v = VCF(
 				rowRanges=GRanges(coordinates$chr[w[,2]], 
 						IRanges(coordinates$pos[w[,2]] - (w[,3]==5), width=1 + (w[,3]==5)), ## If del make one longer..
@@ -145,7 +146,10 @@ bf2Vcf <- function(BF, counts, regions, samples = 1:nrow(counts), err = NULL, mu
 						BF = select(w, BF),
 						PI = select(w, prior),
 						LEN = 1),
-				exptData = list(header = scanVcfHeader(system.file("extdata", "shearwater.vcf", package="deepSNV"))),
+				exptData = list(header = VCFHeader(
+						reference = reference(headerTemplate),
+						samples = as.character(samples),
+						header = append(header(headerTemplate), DataFrame(date=paste(Sys.time()))))),
 				collapsed = FALSE
 		)}else{
 		u = !duplicated(w[,-1, drop=FALSE])
@@ -165,6 +169,7 @@ bf2Vcf <- function(BF, counts, regions, samples = 1:nrow(counts), err = NULL, mu
 		)
 		
 		#rownames(w) = samples[w[,1]]
+		headerTemplate = scanVcfHeader(system.file("extdata", "shearwater2.vcf", package="deepSNV"))
 		v = VCF(
 				rowRanges=GRanges(coordinates$chr[wu[,2]], 
 						IRanges(coordinates$pos[wu[,2]] - (wu[,3]==5), width=1 + (wu[,3]==5)), 
@@ -183,14 +188,15 @@ bf2Vcf <- function(BF, counts, regions, samples = 1:nrow(counts), err = NULL, mu
 						AF = rowMeans(geno$GT),
 						LEN = 1),
 				geno = geno,
-				exptData = list(header = scanVcfHeader(system.file("extdata", "shearwater2.vcf", package="deepSNV"))),
+				exptData = list(header = VCFHeader(
+						reference = reference(headerTemplate),
+						samples = as.character(samples),
+						header = append(header(headerTemplate), DataFrame(date=paste(Sys.time()))))),
 				colData = DataFrame(samples=1:length(samples), row.names=samples),
 				collapsed = TRUE
 		)
 		colnames(v) = samples
 	}
-	metadata(v)$header@samples <- as.character(samples)
-	meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
 	
 	## If no variants found set to zero..
 	if(isNull)

--- a/R/shearwater-functions.R
+++ b/R/shearwater-functions.R
@@ -190,7 +190,7 @@ bf2Vcf <- function(BF, counts, regions, samples = 1:nrow(counts), err = NULL, mu
 		colnames(v) = samples
 	}
 	metadata(v)$header@samples <- as.character(samples)
-	meta(metadata(v)$header)[[1]]["date",1] <- paste(Sys.time())
+	meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
 	
 	## If no variants found set to zero..
 	if(isNull)

--- a/R/shearwaterML.R
+++ b/R/shearwaterML.R
@@ -141,6 +141,7 @@ qvals2Vcf <- function(qvals, counts, regions, samples = 1:nrow(counts), err = NU
   #	m = match(gr[o], rd)
   #	alt = lapply(split(c("A","T","C","G","")[w[o,3]], m), paste, collapse="")
   if(!mvcf){
+    headerTemplate = scanVcfHeader(system.file("extdata", "shearwater.vcf", package="deepSNV"))
     v = VCF(
       rowRanges=GRanges(coordinates$chr[w[,2]], 
                       IRanges(coordinates$pos[w[,2]] - (w[,3]==5), width=1 + (w[,3]==5)), ## If del make one longer..
@@ -162,7 +163,10 @@ qvals2Vcf <- function(qvals, counts, regions, samples = 1:nrow(counts), err = NU
         DP = select(w[,-3], rowSums(totCounts, dims=2)),
         QV = select(w, qvals),
         LEN = 1),
-      expData = list(header = scanVcfHeader(system.file("extdata", "shearwater.vcf", package="deepSNV"))),
+      exptData = list(header = VCFHeader(
+        reference = reference(headerTemplate),
+        samples = as.character(samples),
+        header = append(header(headerTemplate), DataFrame(date=paste(Sys.time()))))),
       collapsed = FALSE
     )}else{
       u = !duplicated(w[,-1, drop=FALSE])
@@ -180,7 +184,7 @@ qvals2Vcf <- function(qvals, counts, regions, samples = 1:nrow(counts), err = NU
         FD = t(mapply(function(i,j){ rowSums(counts[,i,1:5])}, wu[,2],wu[,3])),
         BD = t(mapply(function(i,j){ rowSums(counts[,i,6:10])}, wu[,2],wu[,3]))
       )
-      
+      headerTemplate = scanVcfHeader(system.file("extdata", "shearwaterML.vcf", package="deepSNV"))
       #rownames(w) = samples[w[,1]]
       v = VCF(
         rowRanges=GRanges(coordinates$chr[wu[,2]], 
@@ -199,14 +203,15 @@ qvals2Vcf <- function(qvals, counts, regions, samples = 1:nrow(counts), err = NU
           AF = rowMeans(geno$GT),
           LEN = 1),
         geno = geno,
-		exptData = list(header = scanVcfHeader(system.file("extdata", "shearwaterML.vcf", package="deepSNV"))),
+        exptData = list(header = VCFHeader(
+          reference = reference(headerTemplate),
+          samples = as.character(samples),
+          header = append(header(headerTemplate), DataFrame(date=paste(Sys.time()))))),
         colData = DataFrame(samples=1:length(samples), row.names=samples),
         collapsed = TRUE
       )
       colnames(v) = samples
     }
-  metadata(v)$header@samples <- as.character(samples)
-  meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
   
   ## If no variants found set to zero..
   if(isNull)

--- a/R/shearwaterML.R
+++ b/R/shearwaterML.R
@@ -206,7 +206,7 @@ qvals2Vcf <- function(qvals, counts, regions, samples = 1:nrow(counts), err = NU
       colnames(v) = samples
     }
   metadata(v)$header@samples <- as.character(samples)
-  meta(metadata(v)$header)[[1]]["date",1] <- paste(Sys.time())
+  meta(header(v)) <- append(meta(header(v)), DataFrame(date=paste(Sys.time())))
   
   ## If no variants found set to zero..
   if(isNull)


### PR DESCRIPTION
With the current VariantAnnotation package, this code:

```R
meta(metadata(v)$header)[[1]]["date",1] <- paste(Sys.time())
```
produces invalid VCF output:

```
##fileformat=<ID=fileformat,Value=VCFv4.1>
##fileformat=<ID=date,Value=2022-04-22 14:56:12>
##fileDate=20220422
```

Furthermore, the even older code in _deepSNV-functions.R_ produces run-time errors with current VariantAnnotation, as noted in #13:

```R
metadata(v)$header@header$META["date",1] <- paste(Sys.time())
```

The first commit in this PR is based on one that @tfrayner wrote at a previous job and we have been using for some time to patch an earlier version of deepSNV. It has recently come to my attention that no equivalent has been applied to mainline deepSNV. So this PR improves the code to be compatible with current VariantAnnotation, by using VariantAnnotation's facilities for manipulating headers instead of directly manipulating the implementation innards, which have since changed.

There is a similar potential problem with `metadata(v)$header@samples`, for which VariantAnnotation does not offer a setter method. The second commit refactors both header additions to be done by setting up the `exptData` initial headers more completely instead.

This has been tested by exercising the _shearwater2.vcf_ branch of _shearwater-functions.R_.

Summary: Fixes VCF output; also fixes #13.