### PR TITLE
Don't crash on reads that are missing an NM tag

### DIFF
--- a/R/deepSNV-functions.R
+++ b/R/deepSNV-functions.R
@@ -336,19 +336,19 @@ manhattanPlot <- function(x, col=nt.col){
 #' @param head.clip Should n nucleotides from the head of reads be clipped? Default 0.
 #' @param max.depth The maximal depth for the pileup command. Default 1,000,000.
 #' @param verbose Boolean. Set to TRUE if you want to get additional output.
-#' @param mask Integer indicating which flags to filter. Default 0 (no mask). Try 1796 (BAM_DEF_MASK).
+#' @param mask Integer indicating which flags to filter. Default 0 (no mask). Try 3844  (UNMAP|SECONDARY|QCFAIL|DUP|SUPPLEMENTARY).
 #' @param keepflag Integer indicating which flags to keep. Default 0 (no mask). Try 3  (PAIRED|PROPERLY_PAIRED).
-#' @param max.mismatches Integer indicating maximum MN value to allow in a read. Default NULL (no filter).
+#' @param max.mismatches Integer indicating maximum NM value to allow in a read. Default NULL (no filter).
 #' @return A named \code{\link{matrix}} with rows corresponding to genomic positions and columns for the nucleotide counts (A, T, C, G, -), masked nucleotides (N), (INS)ertions, (DEL)etions, (HEAD)s and (TAIL)s that count how often a read begins and ends at the given position, respectively, 
 #' and the sum of alignment (QUAL)ities, which can be indicative of alignment problems. 
 #' Counts from matches on the reference strand (s=0) are uppercase, counts on the complement (s=1) are lowercase. The returned matrix has 11 * 2 (strands) = 22 columns and (stop - start + 1) rows.
 #' @author Moritz Gerstung
 #' @export bam2R
 #' @examples ## Simple example:
-#' counts <- bam2R(file = system.file("extdata", "test.bam", package="deepSNV"), chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 3120, stop=3140, q = 10, mask = 1769)
+#' counts <- bam2R(file = system.file("extdata", "test.bam", package="deepSNV"), chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 3120, stop=3140, q = 10, mask = 3844)
 #' show(counts)
 #' ## Not run: Requires an internet connection, but try yourself.
-#' # bam <- bam2R(file = "http://www.bsse.ethz.ch/cbg/software/deepSNV/data/test.bam", chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 2074, stop=3585, q=10, mask = 1796)
+#' # bam <- bam2R(file = "http://www.bsse.ethz.ch/cbg/software/deepSNV/data/test.bam", chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 2074, stop=3585, q=10, mask = 3844)
 #' # head(bam)
 bam2R = function(file, chr, start, stop, q=25, mq=0, s=2, head.clip = 0, max.depth=1000000, verbose=FALSE, mask=0, keepflag=0, max.mismatches=NULL){
 	if(is.null(max.mismatches)) max.mismatches <- -1

--- a/man/bam2R.Rd
+++ b/man/bam2R.Rd
@@ -41,11 +41,11 @@ bam2R(
 
 \item{verbose}{Boolean. Set to TRUE if you want to get additional output.}
 
-\item{mask}{Integer indicating which flags to filter. Default 0 (no mask). Try 1796 (BAM_DEF_MASK).}
+\item{mask}{Integer indicating which flags to filter. Default 0 (no mask). Try 3844  (UNMAP|SECONDARY|QCFAIL|DUP|SUPPLEMENTARY).}
 
 \item{keepflag}{Integer indicating which flags to keep. Default 0 (no mask). Try 3  (PAIRED|PROPERLY_PAIRED).}
 
-\item{max.mismatches}{Integer indicating maximum MN value to allow in a read. Default NULL (no filter).}
+\item{max.mismatches}{Integer indicating maximum NM value to allow in a read. Default NULL (no filter).}
 }
 \value{
 A named \code{\link{matrix}} with rows corresponding to genomic positions and columns for the nucleotide counts (A, T, C, G, -), masked nucleotides (N), (INS)ertions, (DEL)etions, (HEAD)s and (TAIL)s that count how often a read begins and ends at the given position, respectively, 
@@ -59,10 +59,10 @@ respectively.
 }
 \examples{
 ## Simple example:
-counts <- bam2R(file = system.file("extdata", "test.bam", package="deepSNV"), chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 3120, stop=3140, q = 10, mask = 1769)
+counts <- bam2R(file = system.file("extdata", "test.bam", package="deepSNV"), chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 3120, stop=3140, q = 10, mask = 3844)
 show(counts)
 ## Not run: Requires an internet connection, but try yourself.
-# bam <- bam2R(file = "http://www.bsse.ethz.ch/cbg/software/deepSNV/data/test.bam", chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 2074, stop=3585, q=10, mask = 1796)
+# bam <- bam2R(file = "http://www.bsse.ethz.ch/cbg/software/deepSNV/data/test.bam", chr="B.FR.83.HXB2_LAI_IIIB_BRU_K034", start = 2074, stop=3585, q=10, mask = 3844)
 # head(bam)
 }
 \author{

--- a/src/bam2R.cpp
+++ b/src/bam2R.cpp
@@ -88,6 +88,17 @@ void bam2R_pileup_function(const bam_pileup1_t *pl, int pos, int n_plp, nttable_
 	kh_destroy(strh, h);
 }
 
+static inline int64_t getNM(const bam1_t *b, unsigned long long& count)
+{
+	const uint8_t *nm = bam_aux_get(b, "NM");
+	if (nm)
+		return bam_aux2i(nm);
+	else {
+		count++;
+		return 0;  // Dummy NM value that always passes the filter
+	}
+}
+
 int bam2R(char** bamfile, char** ref, int* beg, int* end, int* counts, int* q, int* mq, int* s, 
           int* head_clip, int* maxdepth, int* verbose, int* mask, int *keepflag, int *maxmismatches )
 {
@@ -102,6 +113,9 @@ int bam2R(char** bamfile, char** ref, int* beg, int* end, int* counts, int* q, i
 	nttable.head_clip = *head_clip;
 	nttable.i = 0;
 	nttable.counts = counts;
+
+	int64_t maxNM = (*maxmismatches != -1)? *maxmismatches : INT64_MAX;
+	unsigned long long no_NM_count = 0;
 
 	int i;
 	for (i=0; i<N; i++)
@@ -124,21 +138,11 @@ int bam2R(char** bamfile, char** ref, int* beg, int* end, int* counts, int* q, i
   int tid, pos, n_plp = -1;
 	const bam_pileup1_t *pl;
 
-  //get first read to check for NM tag
-  int ret;
-  ret = sam_read1(nttable.in, head, b);
-  hts_close(nttable.in);
-  nttable.in = hts_open(*bamfile, "r");
-  uint8_t *paux = bam_aux_get(b, "NM");
-  if ( ! paux && *maxmismatches != -1 ) {
-    Rf_warning("BAM/CRAM is missing NM tag, ignoring max.mismatches argument.\n");
-    //return 1;
-  }
-
 	if (strcmp(*ref, "") == 0) { // if a region is not specified
 		//Replicate sampileup functionality (uses above mask without supplementary)
+		int ret;
 		while((ret = sam_read1(nttable.in, head, b)) >= 0){
-			if ((b->core.flag & *mask)==0 && b->core.qual >= *mq && (b->core.flag & *keepflag)==*keepflag && ((paux && bam_aux2i(bam_aux_get(b,"NM")) <= *maxmismatches ) || !paux || *maxmismatches == -1)){
+			if ((b->core.flag & *mask)==0 && b->core.qual >= *mq && (b->core.flag & *keepflag)==*keepflag && getNM(b, no_NM_count) <= maxNM) {
 					bam_plp_push(buf, b);
             };
 			while ( (pl=bam_plp_next(buf, &tid, &pos, &n_plp)) != 0) {
@@ -167,7 +171,7 @@ int bam2R(char** bamfile, char** ref, int* beg, int* end, int* counts, int* q, i
 		hts_itr_t *iter = sam_itr_queryi(idx, tid, nttable.beg, nttable.end);
 		int result;
 		while ((result = sam_itr_next(nttable.in, iter, b)) >= 0) {
-			if ((b->core.flag & *mask)==0 && b->core.qual >= *mq && (b->core.flag & *keepflag)==*keepflag && ((paux && bam_aux2i(bam_aux_get(b,"NM")) <= *maxmismatches ) || !paux || *maxmismatches == -1)){
+			if ((b->core.flag & *mask)==0 && b->core.qual >= *mq && (b->core.flag & *keepflag)==*keepflag && getNM(b, no_NM_count) <= maxNM) {
 				bam_plp_push(buf, b);
 			};
 			while ( (pl=bam_plp_next(buf, &tid, &pos, &n_plp)) != 0) {
@@ -187,6 +191,11 @@ int bam2R(char** bamfile, char** ref, int* beg, int* end, int* counts, int* q, i
   while ( (pl=bam_plp_next(buf, &tid, &pos, &n_plp)) != 0) {
     bam2R_pileup_function(pl,pos,n_plp,nttable);
   }
+
+	if (*maxmismatches != -1 && no_NM_count > 0) {
+		Rf_warning("%llu reads did not have NM tags; max.mismatches filter was not applied to them.\n", no_NM_count);
+	}
+
 	bam_destroy1(b);
 	bam_hdr_destroy(head);
 	bam_plp_destroy(buf);


### PR DESCRIPTION
Hi Moritz, here is another bug fix:

Issue #14 is that `loadAllData()` crashes on the following unmapped read:

```
A00349:189:HC2CCDSXX:3:2232:6479:12430	181	chr9	5054726	0	*	=	5054726	0	TTTTTATTTTTGCTCTAATATTTTTTGTTTTTATTTTTTTGTAGCTTGTTAAAAAAAAGCACATACAAAAAAACAC	,FF,,,F,FFF,,F,,,FF,,,FFFF,,F,,:,,:,F,FF,F,,,F,F,F:,FFFF,F,,F,,F::F,FFFFF:,,	MC:Z:76M	PG:Z:MarkDuplicates	MQ:i:60	AS:i:0	XS:i:0	RG:Z:UKB_3491982_233006790.3
```

If the problem is the same as the crash exhibited on our test data, the underlying problem is that the read does not have an NM tag, and the maxmismatches check crashes in this case (when earlier reads in the file do have NM so the check is left activated). Of course, unmapped reads would usually have no NM tags but be sprinkled occasionally though a data file…, thus causing this crash.

This PR introduces a function `getNM()` that returns the NM value if it is present, or increments `no_NM_count` and returns a passes-filter value if no NM tag is present. We then use this function to write the two filter checking expressions in such a way that they do not crash on reads without NM.

We also rewrite the “does the first read have an NM tag” test using `no_NM_count` to print a warning if necessary afterwards, as described in the commit message.

This PR also uses `sam_itr_queryi()` instead of `sam_itr_querys()` so that we don't have to allocate a region string unnecessarily. It also fixes some documentation typos and updates the suggested flag mask value to also discard SUPPLEMENTARY reads.

Fixes #14 (almost certainly).
